### PR TITLE
Swap targets

### DIFF
--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,15 +1,10 @@
 
-nwis_df <- function(filepath, site_csvs){
-  
-  # Join data in site_csvs in one data.frame
+nwis_df <- function(filepath, site_dataframes){
+  # Join data in site_dataframes in one data.frame
   # Write joined data out to a file
-  data_out <- data.frame()
-  # loop through files
-  for (site_csv in site_csvs){
-    # read the downloaded data and append it to the existing data.frame
-    these_data <- read_csv(site_csv, col_types = 'ccTdcc')
-    data_out <- bind_rows(data_out, these_data)
-  }
+  # filepath is the csv file to write to
+  # site_dataframes is a list of data.frames
+  data_out <- bind_rows(site_dataframes)
   write_csv(data_out, file = filepath)
   return(filepath)
 }
@@ -24,12 +19,7 @@ nwis_site_info <- function(fileout, site_data_csv){
 }
 
 
-download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
-  
-  # filepaths look something like directory/nwis_01432160_data.csv,
-  # remove the directory with basename() and extract the 01432160 with the regular expression match
-  site_num <- basename(filepath) %>% 
-    stringr::str_extract(pattern = "(?:[0-9]+)")
+download_nwis_site_data <- function(site_num, parameterCd = '00010', startDate="2014-05-01", endDate="2015-05-01"){
   
   # readNWISdata is from the dataRetrieval package
   data_out <- readNWISdata(sites=site_num, service="iv", 
@@ -42,7 +32,6 @@ download_nwis_site_data <- function(filepath, parameterCd = '00010', startDate="
   }
   # -- end of do-not-edit block
   
-  write_csv(data_out, file = filepath)
-  return(filepath)
+  return(data_out)
 }
 

--- a/1_fetch/src/get_nwis_data.R
+++ b/1_fetch/src/get_nwis_data.R
@@ -1,7 +1,8 @@
 
-nwis_df <- function(site_csvs){
+nwis_df <- function(filepath, site_csvs){
   
   # Join data in site_csvs in one data.frame
+  # Write joined data out to a file
   data_out <- data.frame()
   # loop through files
   for (site_csv in site_csvs){
@@ -9,11 +10,13 @@ nwis_df <- function(site_csvs){
     these_data <- read_csv(site_csv, col_types = 'ccTdcc')
     data_out <- bind_rows(data_out, these_data)
   }
-  return(data_out)
+  write_csv(data_out, file = filepath)
+  return(filepath)
 }
 
 
-nwis_site_info <- function(fileout, site_data){
+nwis_site_info <- function(fileout, site_data_csv){
+  site_data <- read_csv(site_data_csv, col_types = 'ccTdcc')
   site_no <- unique(site_data$site_no)
   site_info <- dataRetrieval::readNWISsite(site_no)
   write_csv(site_info, fileout)

--- a/2_process/src/process_and_style.R
+++ b/2_process/src/process_and_style.R
@@ -1,4 +1,5 @@
-clean_data <- function(nwis_data, nwis_info_filename){
+clean_data <- function(nwis_data_csv, nwis_info_filename){
+  nwis_data <- read_csv(nwis_data_csv, col_types='ccTdcc')
   site_info <- read_csv(nwis_info_filename, show_col_types = FALSE)
   nwis_data_clean <- rename(nwis_data, water_temperature = X_00010_00000) %>% 
     select(-agency_cd, -X_00010_00000_cd, -tz_cd)

--- a/_targets.R
+++ b/_targets.R
@@ -15,53 +15,48 @@ p_units <- "in"
 
 p1_targets_list <- list(
   tar_target(
-    site_data_01427207_csv,
-    download_nwis_site_data(file.path("1_fetch", "out", "nwis_01427207_data.csv"), 
+    site_data_01427207,
+    download_nwis_site_data("01427207", 
                             parameterCd = nwis_Cd,
                             startDate = start_date,
-                            endDate = end_date),
-    format = "file"
+                            endDate = end_date)
   ),
   tar_target(
-    site_data_01432160_csv,
-    download_nwis_site_data(file.path("1_fetch", "out", "nwis_01432160_data.csv"), 
+    site_data_01432160,
+    download_nwis_site_data("01432160", 
                             parameterCd = nwis_Cd,
                             startDate = start_date,
-                            endDate = end_date),
-    format = "file"
+                            endDate = end_date)
   ),
   tar_target(
-    site_data_01435000_csv,
-    download_nwis_site_data(file.path("1_fetch", "out", "nwis_01435000_data.csv"), 
+    site_data_01435000,
+    download_nwis_site_data("01435000", 
                             parameterCd = nwis_Cd,
                             startDate = start_date,
-                            endDate = end_date),
-    format = "file"
+                            endDate = end_date)
   ),
   tar_target(
-    site_data_01436690_csv,
-    download_nwis_site_data(file.path("1_fetch", "out", "nwis_01436690_data.csv"), 
+    site_data_01436690,
+    download_nwis_site_data("01436690", 
                             parameterCd = nwis_Cd,
                             startDate = start_date,
-                            endDate = end_date),
-    format = "file"
+                            endDate = end_date)
   ),
   tar_target(
-    site_data_01466500_csv,
-    download_nwis_site_data(file.path("1_fetch", "out", "nwis_01466500_data.csv"), 
+    site_data_01466500,
+    download_nwis_site_data("01466500", 
                             parameterCd = nwis_Cd,
                             startDate = start_date,
-                            endDate = end_date),
-    format = "file"
+                            endDate = end_date)
   ),
   tar_target(
     site_data_csv,
     nwis_df(file.path("1_fetch", "out", "site_data.csv"),
-            c(site_data_01427207_csv,
-              site_data_01432160_csv,
-              site_data_01435000_csv,
-              site_data_01436690_csv,
-              site_data_01466500_csv)),
+            list(site_data_01427207,
+                 site_data_01432160,
+                 site_data_01435000,
+                 site_data_01436690,
+                 site_data_01466500)),
     format = "file"
   ),
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -55,16 +55,18 @@ p1_targets_list <- list(
     format = "file"
   ),
   tar_target(
-    site_data,
-    nwis_df(c(site_data_01427207_csv,
+    site_data_csv,
+    nwis_df(file.path("1_fetch", "out", "site_data.csv"),
+            c(site_data_01427207_csv,
               site_data_01432160_csv,
               site_data_01435000_csv,
               site_data_01436690_csv,
               site_data_01466500_csv)),
+    format = "file"
   ),
   tar_target(
     site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data),
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data_csv),
     format = "file"
   )
 )
@@ -72,7 +74,7 @@ p1_targets_list <- list(
 p2_targets_list <- list(
   tar_target(
     site_data_clean, 
-    clean_data(site_data, site_info_csv)
+    clean_data(site_data_csv, site_info_csv)
   )
 )
 


### PR DESCRIPTION
To understand file targets vs object targets (see #8), change:

- `site_data` from an object target to a file target (`site_data` is the concatenation of the downloaded data, before cleaning).
- `site_data_014XXXXX` from file targets to object targets (these are the raw downloads)

Note to self: one tricky thing was that `c()` works for strings (file paths), but not for data.frames. Use `list()` instead of `c()` to combine data.frames into a list.

Here's the build status (after the most recent change):
<img width="264" alt="Screen Shot 2021-09-20 at 5 33 05 PM" src="https://user-images.githubusercontent.com/11847289/134090120-654d304e-28ac-4f80-bba9-568b7c92911a.png">

