### PR TITLE
Split targets among phase makefiles

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,0 +1,58 @@
+source("1_fetch/src/get_nwis_data.R")
+
+nwis_Cd <- "00010"
+start_date <- "2014-05-01"
+end_date <- "2015-05-01"
+
+p1_targets_list <- list(
+  tar_target(
+    p1_site_data_01427207,
+    download_nwis_site_data("01427207", 
+                            parameterCd = nwis_Cd,
+                            startDate = start_date,
+                            endDate = end_date)
+  ),
+  tar_target(
+    p1_site_data_01432160,
+    download_nwis_site_data("01432160", 
+                            parameterCd = nwis_Cd,
+                            startDate = start_date,
+                            endDate = end_date)
+  ),
+  tar_target(
+    p1_site_data_01435000,
+    download_nwis_site_data("01435000", 
+                            parameterCd = nwis_Cd,
+                            startDate = start_date,
+                            endDate = end_date)
+  ),
+  tar_target(
+    p1_site_data_01436690,
+    download_nwis_site_data("01436690", 
+                            parameterCd = nwis_Cd,
+                            startDate = start_date,
+                            endDate = end_date)
+  ),
+  tar_target(
+    p1_site_data_01466500,
+    download_nwis_site_data("01466500", 
+                            parameterCd = nwis_Cd,
+                            startDate = start_date,
+                            endDate = end_date)
+  ),
+  tar_target(
+    p1_site_data_csv,
+    nwis_df(file.path("1_fetch", "out", "site_data.csv"),
+            list(p1_site_data_01427207,
+                 p1_site_data_01432160,
+                 p1_site_data_01435000,
+                 p1_site_data_01436690,
+                 p1_site_data_01466500)),
+    format = "file"
+  ),
+  tar_target(
+    p1_site_info_csv,
+    nwis_site_info(fileout = "1_fetch/out/site_info.csv", p1_site_data_csv),
+    format = "file"
+  )
+)

--- a/2_process.R
+++ b/2_process.R
@@ -1,0 +1,8 @@
+source("2_process/src/process_and_style.R")
+
+p2_targets_list <- list(
+  tar_target(
+    p2_site_data_clean, 
+    clean_data(p1_site_data_csv, p1_site_info_csv)
+  )
+)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,0 +1,14 @@
+source("3_visualize/src/plot_timeseries.R")
+
+p_width <- 12
+p_height <- 7
+p_units <- "in"
+
+p3_targets_list <- list(
+  tar_target(
+    p3_figure_1_png,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", p2_site_data_clean,
+                         width = p_width, height = p_height, units = p_units),
+    format = "file"
+  )
+)

--- a/_targets.R
+++ b/_targets.R
@@ -1,86 +1,11 @@
 library(targets)
-source("1_fetch/src/get_nwis_data.R")
-source("2_process/src/process_and_style.R")
-source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 
-nwis_Cd <- "00010"
-start_date <- "2014-05-01"
-end_date <- "2015-05-01"
-p_width <- 12
-p_height <- 7
-p_units <- "in"
-
-p1_targets_list <- list(
-  tar_target(
-    site_data_01427207,
-    download_nwis_site_data("01427207", 
-                            parameterCd = nwis_Cd,
-                            startDate = start_date,
-                            endDate = end_date)
-  ),
-  tar_target(
-    site_data_01432160,
-    download_nwis_site_data("01432160", 
-                            parameterCd = nwis_Cd,
-                            startDate = start_date,
-                            endDate = end_date)
-  ),
-  tar_target(
-    site_data_01435000,
-    download_nwis_site_data("01435000", 
-                            parameterCd = nwis_Cd,
-                            startDate = start_date,
-                            endDate = end_date)
-  ),
-  tar_target(
-    site_data_01436690,
-    download_nwis_site_data("01436690", 
-                            parameterCd = nwis_Cd,
-                            startDate = start_date,
-                            endDate = end_date)
-  ),
-  tar_target(
-    site_data_01466500,
-    download_nwis_site_data("01466500", 
-                            parameterCd = nwis_Cd,
-                            startDate = start_date,
-                            endDate = end_date)
-  ),
-  tar_target(
-    site_data_csv,
-    nwis_df(file.path("1_fetch", "out", "site_data.csv"),
-            list(site_data_01427207,
-                 site_data_01432160,
-                 site_data_01435000,
-                 site_data_01436690,
-                 site_data_01466500)),
-    format = "file"
-  ),
-  tar_target(
-    site_info_csv,
-    nwis_site_info(fileout = "1_fetch/out/site_info.csv", site_data_csv),
-    format = "file"
-  )
-)
-
-p2_targets_list <- list(
-  tar_target(
-    site_data_clean, 
-    clean_data(site_data_csv, site_info_csv)
-  )
-)
-
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_clean,
-                         width = p_width, height = p_height, units = p_units),
-    format = "file"
-  )
-)
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
Move the definitions of targets out of `_targets.R` and into 3 new makefiles, one for each phase. I had a couple of learnings:

- In `_targets.R`, `tar_option_set()` must be called before the phase-specific makefiles are sourced; otherwise those packages won't be accessible when making targets.
- Alternatively, each phase-specific makefile could have its own call to `tar_option_set()` and load its own packages.

Build status:
<img width="607" alt="Screen Shot 2021-09-21 at 11 48 58 AM" src="https://user-images.githubusercontent.com/11847289/134225274-7206f348-62a1-45a5-b19c-c24d28762fc2.png">

